### PR TITLE
Update constants.tsx

### DIFF
--- a/src/utils/constants.tsx
+++ b/src/utils/constants.tsx
@@ -230,13 +230,13 @@ const constants = {
     },
   ],
 
-  GTM_ID: "GTM-TC768WT",
+  GTM_ID: "",
   /**
    * * @mehowbrainz twitter developer account
    */
   TWITTER_EVENT: {
-    PIXEL_ID: "o3khw",
-    EVENT_ID: "tw-o3khw-oi8v5",
+    PIXEL_ID: "",
+    EVENT_ID: "",
   },
 };
 


### PR DESCRIPTION
Remove trackers related to zenon.org tracking and affiliate marketing program.  These tracking and conversion activities have nothing to do with Zenon Network.  Can you please create a separate branch and URL for zenon.org affiliate marketing activities so they can track their users separately?  